### PR TITLE
通知内容に投稿内容やスレッド名を反映させる

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,7 @@ A+つくばに存在しないスレッドIDも登録できるので注意
 `DELETE api/thread/<thread_id>/unsubscribe` で購読解除する．デバイスレコードや購読情報レコード，指定されたスレッドが存在しない場合はエラーになるが，指定されたスレッドが存在し，かつ購読状態でない場合に購読解除してもエラーにはならない．
 
 ### 通知を送信する
-```python manage.py notice スレッドID```
+```
+python manage.py notice thread_id thread_title body type post_id reply_id
+```
 で更新通知を送ります．

--- a/app/management/commands/notice.py
+++ b/app/management/commands/notice.py
@@ -8,6 +8,12 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('thread_id', type=int, help='スレッドID', default=-1)
+        parser.add_argument('thread_title', type=str, help='スレッドタイトル', default='')
+        parser.add_argument('body', type=str, help='投稿内容', default='')
+        parser.add_argument('type', type=str, help='postかreplyか', default='post')
+        parser.add_argument('post_id', type=str, help='post_id', default='')
+        parser.add_argument('reply_id', type=str, help='reply_id', default='')
+        
     
     def handle(self, *args, **options):
         thread_id = options['thread_id']
@@ -16,17 +22,26 @@ class Command(BaseCommand):
             # 指定されたスレッドIDを購読しているユーザはいない
             return
         
+        title = options['thread_title']
+        if options['type'] == 'post':
+            title = f'{title}に新しい投稿があります'
+        else:
+            title = f'{title}に新しい返信があります'
+
         # 通知を送信
         for target in targets:
             try:
                 target.device.send_message(
                     Message(
                         notification=Notification(
-                            title='A+つくばに新しい投稿があります', 
-                            body='タップして新しい投稿を確認しましょう',
+                            title=title, 
+                            body=options['body'],
                         ),
                         data={
                             'thread_id': str(thread_id), # str()でキャストしないとエラーになる
+                            'type': options['type'], # 'post' or 'reply'
+                            'post_id': options['post_id'],
+                            'reply_id': options['reply_id'],
                         }
                     )
                 )

--- a/batch_check_update.py
+++ b/batch_check_update.py
@@ -29,6 +29,19 @@ def mysql_connect(user: str, password: str, host: str, db_name: str, port: int =
                            charset="utf8mb4")
     return conn
 
+class NoticeMsg:
+    def __init__(self, thread_id: int, title: str, body: str, content_type: str, post_id: str, reply_id: str = ""):
+        self.thread_id = thread_id
+        self.title = title
+        self.body = body
+        self.content_type = content_type
+        assert content_type in ["post", "reply"]
+        self.post_id = post_id
+        if content_type == "reply":
+            self.reply_id = reply_id
+        else:
+            self.reply_id = ""
+
 def main():
     config = load_config()
 
@@ -70,29 +83,48 @@ def main():
             f.write(new_timestamp.isoformat())
 
     # 通知をすべきスレッドを取得する
-    thread_ids = set()
+    new_posts_and_replies = [] # List[NoticeMsg]
     cur.execute(
-        r"SELECT DISTINCT thread_id FROM board_post WHERE created_at > %s;",
+        r"""
+        SELECT 
+            board_post.thread_id,
+            board_thread.title,
+            board_post.text,
+            board_post.post_id
+        FROM board_post
+        INNER JOIN board_thread ON board_post.thread_id = board_thread.id
+        WHERE created_at > %s;
+        """,
         [timestamp.strftime('%Y-%m-%d %H:%M:%S.%f')],
     )
     for row in cur.fetchall():
-        thread_ids.add(row[0])
+        notice_msg = NoticeMsg(thread_id=row[0], title=row[1], body=row[2], content_type="post", post_id=row[3])
+        new_posts_and_replies.append(notice_msg)
     cur.execute(
         r"""
-        SELECT DISTINCT board_post.thread_id FROM board_reply 
+        SELECT
+        board_post.thread_id,
+        board_thread.title,
+        board_reply.text,
+        board_post.post_id,
+        board_reply.reply_id
+        FROM board_reply 
         INNER JOIN board_post ON board_reply.post_id_id = board_post.post_id 
+        INNER JOIN board_thread ON board_post.thread_id = board_thread.id
         WHERE board_reply.created_at > %s ;
         """,
         [timestamp.strftime('%Y-%m-%d %H:%M:%S.%f')],
     )
     for row in cur.fetchall():
-        thread_ids.add(row[0])
+        notice_msg = NoticeMsg(thread_id=row[0], title=row[1], body=row[2],
+                                content_type="reply", post_id=row[3], reply_id=row[4])
+        new_posts_and_replies.append(notice_msg)
     
     # 通知を送信する
-    for tid in thread_ids:
-        logging.info("通知を送信します: thread_id = {}".format(tid))
-        subprocess.run([RUNTIME, ABS_PATH, "notice", str(tid)])
-    if len(thread_ids) == 0:
+    for msg in new_posts_and_replies:
+        logging.info(f"通知を送信します: thread_id: {msg.thread_id}, type: {msg.content_type}, post_id: {msg.post_id}, reply_id: {msg.reply_id}")
+        subprocess.run([RUNTIME, ABS_PATH, "notice", str(msg.thread_id), msg.title, msg.body, msg.content_type, msg.post_id, msg.reply_id])
+    if len(new_posts_and_replies) == 0:
         logging.info("通知を送信するスレッドはありませんでした")
     return
 


### PR DESCRIPTION
### 変更内容
 - 新しいpostやreplyがあるたびに、その内容を通知内容に含めた通知を送信するようにした
 - 通知のpayloadにpost_idとreply_id、type (post or reply) を追加した
 
### 互換性に関するメモ
 - このPRは現行Releaseのアプリの動作を妨げない
 - 通知内容は新しくなるがタップされたときの挙動はそのまま
 
### 試し方
ネイティブアプリが参照するA+つくば本体とFCMサーバをngrokの本体とFCMサーバに書き換えている場合はそのまま試せます。

アプリ側を書き換えない場合は、

 1. エミュレータ(Androidのみ)や実機のfcmトークンを取得する
 2. `FCMサーバーのDockerを起動する（README.md参照）
 3. `http://localhost:8001/admin/`にアクセスし、1のfcmトークンを登録し、任意のスレッドを購読状態に設定する
 4. `http://localhost:8000/`に書き込むと通知が送信されます。

通知送信スクリプトのログは、
1. ` docker exec -it  a_plus_tsukuba-fcm bash`
2. `tail -f /var/log/batch_fcm_error.log`

で見れます。

### 試したこと
 - 長い投稿
 - Unicode絵文字を含んだ投稿
 - 怪しそうな記号などを含んだ投稿（通知はカスタムコマンドで発火し、シェルの引数でbody等を送っている）

### 画像
![image](https://github.com/half-blue/aplus_mobile_fcm_server/assets/40143183/f4798c25-af69-4ba6-8ffa-183210a7e14a)
![image](https://github.com/half-blue/aplus_mobile_fcm_server/assets/40143183/edd2646b-442c-4e89-9617-a0a6cebf8f3e)
![image](https://github.com/half-blue/aplus_mobile_fcm_server/assets/40143183/3e6f3422-3d54-48a4-be53-fcd6181513cb)
